### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build-api.yaml
+++ b/.github/workflows/build-api.yaml
@@ -1,4 +1,6 @@
 name: Build Checks for API
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/BRAVO68WEB/api/security/code-scanning/4](https://github.com/BRAVO68WEB/api/security/code-scanning/4)

The best way to fix this problem is to explicitly specify the permissions required by the workflow, using the `permissions` key. Since none of the steps in the workflow appear to require write access (they only check out code and run build scripts), the minimum required permission is likely `contents: read`. This can be added either globally at the root of the workflow, or scoped to the `build` job. For this case, per CodeQL guidance, adding `permissions: contents: read` at the root level (line 2, after `name:` but before `on:`) will apply to all jobs in the workflow unless overridden, which is the recommended approach.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
